### PR TITLE
Create SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,35 @@
+## Security
+
+We take the security of our software products and services seriously, which includes all source code repositories managed through our GitHub organizations.
+
+If you believe you have found a security vulnerability in any freephile-owned repository that meets [CVE definition of a security vulnerability](https://www.cve.org/ResourcesSupport/Glossary#glossaryVulnerability), please report it to us as described below.
+
+## Reporting Security Issues
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+Instead, please report them in our secure, Security Response Center at https://github.com/freephile/meza/security.
+
+If you prefer to submit without using GitHub, send email to https://github.com/freephile.  If possible, encrypt your message with our PGP key; please download it from MIT's PGP keystore https://pgp.mit.edu/pks/lookup?op=get&search=0x260A8B5756996D18
+
+You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. 
+
+Please include the requested information listed below (as much as you can provide) to help us better understand the nature and scope of the possible issue:
+
+  * Type of issue (e.g. buffer overflow, SQL injection, cross-site scripting, etc.)
+  * Full paths of source file(s) related to the manifestation of the issue
+  * The location of the affected source code (tag/branch/commit or direct URL)
+  * Any special configuration required to reproduce the issue
+  * Step-by-step instructions to reproduce the issue
+  * Proof-of-concept or exploit code (if possible)
+  * Impact of the issue, including how an attacker might exploit the issue
+
+This information will help us triage your report more quickly.
+
+## Preferred Languages
+
+We prefer all communications to be in English.
+
+## Policy
+
+We follow the principle of [Coordinated Vulnerability Disclosure](https://en.wikipedia.org/wiki/Coordinated_vulnerability_disclosure).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,21 +8,21 @@ If you believe you have found a security vulnerability in any freephile-owned re
 
 **Please do not report security vulnerabilities through public GitHub issues.**
 
-Instead, please report them in our secure, Security Response Center at https://github.com/freephile/meza/security.
+Instead, please report them in our secure, [Security Response Center](https://github.com/freephile/meza/security) (or click the 'Security' heading at the top of the page).
 
-If you prefer to submit without using GitHub, send email to https://github.com/freephile.  If possible, encrypt your message with our PGP key; please download it from MIT's PGP keystore https://pgp.mit.edu/pks/lookup?op=get&search=0x260A8B5756996D18
+If you prefer to submit without using GitHub, send email to Greg DOT Rundlett AT gmail.com.  If possible, encrypt your message with our PGP key; please download it from [MIT's PGP keystore](https://pgp.mit.edu/pks/lookup?op=get&search=0x260A8B5756996D18)
 
-You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. 
+You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message.
 
 Please include the requested information listed below (as much as you can provide) to help us better understand the nature and scope of the possible issue:
 
-  * Type of issue (e.g. buffer overflow, SQL injection, cross-site scripting, etc.)
-  * Full paths of source file(s) related to the manifestation of the issue
-  * The location of the affected source code (tag/branch/commit or direct URL)
-  * Any special configuration required to reproduce the issue
-  * Step-by-step instructions to reproduce the issue
-  * Proof-of-concept or exploit code (if possible)
-  * Impact of the issue, including how an attacker might exploit the issue
+* Type of issue (e.g. buffer overflow, SQL injection, cross-site scripting, etc.)
+* Full paths of source file(s) related to the manifestation of the issue
+* The location of the affected source code (tag/branch/commit or direct URL)
+* Any special configuration required to reproduce the issue
+* Step-by-step instructions to reproduce the issue
+* Proof-of-concept or exploit code (if possible)
+* Impact of the issue, including how an attacker might exploit the issue
 
 This information will help us triage your report more quickly.
 


### PR DESCRIPTION
GitHub reads this root-level file as the repository's Security Policy (IOW it's standard)

### Changes

Creates a SECURITY.md

### Issues

* Closes #174 

### Post-merge actions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a security policy outlining how to report vulnerabilities and the expected response process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->