### PR TITLE
Issue267 faster deploy

### DIFF
--- a/config/ansible.cfg
+++ b/config/ansible.cfg
@@ -1,13 +1,16 @@
 [defaults]
-; https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_debugger.html
-; comment the next line, or set to false to disable Ansible debugging
+# https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_debugger.html
+# comment the next line, or set to false to disable Ansible debugging
 enable_task_debugger = true
 
-callback_enabled = profile_tasks
+# Configure profiling in Ansible to see task duration times
+# https://docs.ansible.com/ansible/latest/plugins/callback/profile_tasks.html
+
+callbacks_enabled = profile_tasks
 
 retry_files_save_path = /tmp
 
-; used by ansible-galaxy and other commands
+# used by ansible-galaxy and other commands
 roles_path = ../src/roles
 
 # collections_path = /root/.ansible/collections:/usr/share/ansible/collections:/root/.local/lib/python3.6/site-packages/ansible_collections
@@ -17,21 +20,21 @@ ansible_managed = Ansible managed from template {file} on controller {host} by u
 
 ansible_user = meza-ansible
 
-; Required if doing remote-to-remote communication (as opposed to
-; controller-to-remote) without setting up keys between the remotes. This may
-; not be ideal from a security perspective. Instead, there is a role for
-; granting the controller's keys to remotes, and a separate role for revoking.
-; [ssh_connection]
-; ssh_args=-o ForwardAgent=yes
+# Required if doing remote-to-remote communication (as opposed to
+# controller-to-remote) without setting up keys between the remotes. This may
+# not be ideal from a security perspective. Instead, there is a role for
+# granting the controller's keys to remotes, and a separate role for revoking.
+# [ssh_connection]
+# ssh_args=-o ForwardAgent=yes
 
-; human-readable stdout/stderr results display
-; https://github.com/ansible/ansible/issues/27078
-; options: debug, minimal, yaml
+# human-readable stdout/stderr results display
+# https://github.com/ansible/ansible/issues/27078
+# options: debug, minimal, yaml
 stdout_callback = debug
 
-; Connect to one remote/parallel process at a time if you run out of memory
-; using <= 2GB RAM host
-; forks = 1
+# Connect to one remote/parallel process at a time if you run out of memory
+# using <= 2GB RAM host
+# forks = 1
 
 remote_tmp = /tmp/${USER}/ansible
 
@@ -42,6 +45,12 @@ force_color = 1
 
 # Turn off deprecation warnings by setting this to 'False'
 deprecation_warnings=True
+
+# Uncomment to limit task profiling output
+# [callback_profile_tasks]
+## Limit number of tasks shown in the profile report
+# task_output_limit = 20
+
 
 [ssh_connection]
 

--- a/src/roles/apache-php/README_PROFILING.md
+++ b/src/roles/apache-php/README_PROFILING.md
@@ -480,6 +480,7 @@ mv xhgui-archive-*.tar.gz /opt/data-meza/backups/
 ## Resources
 
 - [MediaWiki Profiling Documentation](https://www.mediawiki.org/wiki/Manual:Profiling)
+- [Meza Profiling](https://wiki.freephile.org/wiki/Meza/profiling)
 - [xhprof GitHub Repository](https://github.com/longxinH/xhprof)
 - [PHP Performance Profiling Guide](https://www.php.net/manual/en/book.xhprof.php)
 - [Meza Configuration Documentation](https://www.mediawiki.org/wiki/Meza)

--- a/src/roles/mediawiki/tasks/main.yml
+++ b/src/roles/mediawiki/tasks/main.yml
@@ -72,16 +72,7 @@
   failed_when: false
   tags:
     - mediawiki-core
-- name: Ensure MediaWiki core owned by meza-ansible
-  file:
-    path: "{{ m_mediawiki }}"
-    mode: "{{ m_htdocs_mode }}"
-    owner: "{{ m_htdocs_owner }}"
-    group: "{{ group_apache }}"
-    state: directory
-    recurse: true
-  tags:
-    - mediawiki-core
+
 - name: Ensure proper MediaWiki git version installed
   become: true
   become_user: "meza-ansible"
@@ -273,11 +264,23 @@
 - name: Run composer update on MediaWiki and composer local extensions
   become: true
   become_user: "meza-ansible"
-  composer:
-    command: update
-    working_dir: "{{ m_mediawiki }}"
-    no_dev: "{{ m_disable_composer_dev_dependencies| default(false, true) }}"
-    prefer_source: true
+  # Explicitly set umask 0002 for composer operations
+  # The Ansible composer module doesn't support umask parameter (unlike git module)
+  # Without this, composer inherits restrictive umask (often 0022) and creates files
+  # in vendor/ directory with permissions 0644/0755 instead of 0664/0775
+  # This causes permission issues when:
+  #   - Apache needs to write cache files
+  #   - meza-ansible needs to update composer dependencies
+  # Using shell with explicit umask ensures group-writable files (apache group)
+  environment:
+    TMPDIR: "{{ m_tmp }}"
+  shell: |
+    umask 0002
+    composer update {{ '--no-dev' if m_disable_composer_dev_dependencies | default(false, true) else '' }} --prefer-source
+  args:
+    chdir: "{{ m_mediawiki }}"
+  register: composer_result
+  changed_when: "'Nothing to install, update or remove' not in composer_result.stdout"
   tags:
     - extensions
     - composer-extensions
@@ -340,6 +343,22 @@
     - latest
 
 #
+# VERIFY AND FIX PERMISSIONS
+#
+# Now that MediaWiki core, extensions, skins, and composer dependencies are all
+# installed, verify and fix all permissions. This includes both general MediaWiki
+# files and special cases (Widgets, cache, uploads).
+- name: Verify and fix all MediaWiki permissions and ownership
+  ansible.builtin.include_role:
+    name: verify-permissions
+  tags:
+    - mediawiki-core
+    - extensions
+    - verify
+    - permissions
+    - file-perms
+
+#
 # LocalSettings.php
 #
 
@@ -351,47 +370,10 @@
     owner: "{{ m_htdocs_owner }}"
     group: "{{ group_apache }}"
 
-- name: Ensure MediaWiki still properly owned
-  file:
-    path: "{{ m_mediawiki }}"
-    mode: "{{ m_htdocs_mode }}"
-    owner: "{{ m_htdocs_owner }}"
-    group: "{{ group_apache }}"
-    state: directory
-    recurse: true
-  tags:
-    - mediawiki-core
-    - file-perms
-
-- name: Check if the compiled_templates directory exists
-  stat:
-    path: "{{ m_mediawiki }}/extensions/Widgets/compiled_templates/"
-  register: compiled_templates_folder
-
-- name: "Ensure compiled templates folder for widget extension is owned by apache"
-  file:
-    path: "{{ m_mediawiki }}/extensions/Widgets/compiled_templates/"
-    owner: "{{ user_apache }}"
-    group: "{{ group_apache }}"
-    mode: "u=rwX,g=rwX,o=rX"
-    state: directory
-    recurse: true
-    modification_time: preserve
-    access_time: preserve
-  when: compiled_templates_folder.stat.exists
-
-- name: Ensure all MediaWiki directories have proper group permissions
-  file:
-    path: "{{ item }}"
-    state: directory
-    group: "{{ group_apache }}"
-    mode: "g+rwX"
-    recurse: true
-  loop:
-    - "{{ m_mediawiki }}/cache"
-    - "{{ m_mediawiki }}/images"
-    - "{{ m_uploads_dir }}"
-  when: ansible_distribution_file_variety == 'RedHat'
+# NOTE: All MediaWiki permissions are now handled by the verify-permissions
+# role included after all MediaWiki components are installed (line ~320).
+# This includes general ownership/permissions plus edge cases like Widgets,
+# cache, images, and uploads directories.
 
 #
 # LANDING PAGE

--- a/src/roles/verify-permissions/tasks/main.yml
+++ b/src/roles/verify-permissions/tasks/main.yml
@@ -1,5 +1,14 @@
 ---
 # Verify meza-ansible group memberships and critical directory permissions
+# Also verify and correct MediaWiki directory ownership and permissions
+# This verify-permissions playbook can be run independently to check and fix permissions
+# Usage:
+## If you are in the config directory, it will be picked up automatically
+# cd /opt/meza/config
+## Run ansible-playbook specifying the config as well as the inventory
+## using 'localhost, --connection=local' for local runs
+## and finally specifying the 'env' extra var to satisfy the 'set-vars' role
+# ANSIBLE_CONFIG=/opt/meza/config/ansible.cfg ansible-playbook -i localhost, --connection=local  /opt/meza/src/playbooks/verify-permissions.yml -e env=monolith
 
 - name: Verify meza-ansible group memberships
   ansible.builtin.command: groups meza-ansible
@@ -56,3 +65,160 @@
     path: "{{ m_cache_directory }}/test-write"
     state: absent
   when: cache_write_test is succeeded
+
+#
+# MEDIAWIKI DIRECTORY PERMISSIONS VERIFICATION AND CORRECTION
+#
+- name: Check for MediaWiki files with incorrect ownership
+  ansible.builtin.shell: |
+    set -o pipefail
+    find "{{ m_mediawiki }}" \( ! -user {{ m_htdocs_owner }} -o ! -group {{ group_apache }} \) -print | head -100
+  args:
+    executable: /bin/bash
+  register: mediawiki_bad_ownership
+  changed_when: false
+  failed_when: false
+  when: m_mediawiki is defined
+
+- name: Display files with incorrect ownership (first 100)
+  ansible.builtin.debug:
+    msg: "Found {{ mediawiki_bad_ownership.stdout_lines | length }} files with incorrect ownership (showing max 100)"
+  when:
+    - m_mediawiki is defined
+    - mediawiki_bad_ownership.stdout_lines | length > 0
+
+- name: Fix ownership on MediaWiki files
+  ansible.builtin.shell: |
+    set -o pipefail
+    find "{{ m_mediawiki }}" \( ! -user {{ m_htdocs_owner }} -o ! -group {{ group_apache }} \) \
+      -exec chown {{ m_htdocs_owner }}:{{ group_apache }} '{}' \; \
+      -print
+  args:
+    executable: /bin/bash
+  register: mediawiki_ownership_fixed
+  changed_when: mediawiki_ownership_fixed.stdout_lines | length > 0
+  when:
+    - m_mediawiki is defined
+    - mediawiki_bad_ownership.stdout_lines | length > 0
+
+- name: Report ownership changes
+  ansible.builtin.debug:
+    msg:
+      - "Fixed ownership on {{ mediawiki_ownership_fixed.stdout_lines | length }} files"
+      - "Changed files: {{ mediawiki_ownership_fixed.stdout_lines[:100] }}"
+  when:
+    - m_mediawiki is defined
+    - mediawiki_ownership_fixed.stdout_lines | default([]) | length > 0
+
+# Now that composer umask is fixed (line ~265 in mediawiki role), we only need
+# to ensure group-write permissions exist. We do NOT strip execute bits from
+# legitimate executables (maintenance scripts, git hooks, vendor binaries, etc.)
+
+- name: Check for MediaWiki files without group-write permission
+  ansible.builtin.shell: >
+    set -o pipefail &&
+    find "{{ m_mediawiki }}" -type f \! -perm -g+w -print | head -100
+  args:
+    executable: /bin/bash
+  register: mediawiki_bad_file_perms
+  changed_when: false
+  failed_when: false
+  when: m_mediawiki is defined
+
+- name: Check for MediaWiki directories without proper permissions
+  ansible.builtin.shell: >
+    set -o pipefail &&
+    find "{{ m_mediawiki }}" -type d \! -perm -g+rwx -print | head -100
+  args:
+    executable: /bin/bash
+  register: mediawiki_bad_dir_perms
+  changed_when: false
+  failed_when: false
+  when: m_mediawiki is defined
+
+- name: Add group-write permission to MediaWiki files (preserves execute bits)
+  ansible.builtin.shell: >
+    set -o pipefail &&
+    find "{{ m_mediawiki }}" -type f \! -perm -g+w
+    -exec chmod g+w '{}' \;
+    -print
+  args:
+    executable: /bin/bash
+  register: mediawiki_file_perms_fixed
+  changed_when: mediawiki_file_perms_fixed.stdout_lines | length > 0
+  when:
+    - m_mediawiki is defined
+    - mediawiki_bad_file_perms.stdout_lines | length > 0
+
+- name: Report file permission changes
+  ansible.builtin.debug:
+    msg:
+      - "Fixed permissions on {{ mediawiki_file_perms_fixed.stdout_lines | length }} files"
+      - "Changed files (first 100): {{ mediawiki_file_perms_fixed.stdout_lines[:100] }}"
+  when:
+    - m_mediawiki is defined
+    - mediawiki_file_perms_fixed.stdout_lines | default([]) | length > 0
+
+- name: Add group-rwx permission to MediaWiki directories
+  ansible.builtin.shell: >
+    set -o pipefail &&
+    find "{{ m_mediawiki }}" -type d \! -perm -g+rwx
+    -exec chmod g+rwx '{}' \;
+    -print
+  args:
+    executable: /bin/bash
+  register: mediawiki_dir_perms_fixed
+  changed_when: mediawiki_dir_perms_fixed.stdout_lines | length > 0
+  when:
+    - m_mediawiki is defined
+    - mediawiki_bad_dir_perms.stdout_lines | length > 0
+
+- name: Report directory permission changes
+  ansible.builtin.debug:
+    msg:
+      - "Fixed permissions on {{ mediawiki_dir_perms_fixed.stdout_lines | length }} directories"
+      - "Changed directories (first 100): {{ mediawiki_dir_perms_fixed.stdout_lines[:100] }}"
+  when:
+    - m_mediawiki is defined
+    - mediawiki_dir_perms_fixed.stdout_lines | default([]) | length > 0
+
+#
+# MEDIAWIKI EDGE CASES - SPECIAL DIRECTORIES
+#
+# Some directories need special handling because Apache needs write access
+# (not just the standard read access for meza-ansible:apache ownership)
+
+- name: Check if the Widgets compiled_templates directory exists
+  ansible.builtin.stat:
+    path: "{{ m_mediawiki }}/extensions/Widgets/compiled_templates/"
+  register: compiled_templates_folder
+  when: m_mediawiki is defined
+
+- name: Ensure Widgets compiled_templates folder is owned by apache with write access
+  ansible.builtin.file:
+    path: "{{ m_mediawiki }}/extensions/Widgets/compiled_templates/"
+    owner: "{{ user_apache }}"
+    group: "{{ group_apache }}"
+    mode: "u=rwX,g=rwX,o=rX"
+    state: directory
+    recurse: true
+    modification_time: preserve
+    access_time: preserve
+  when:
+    - m_mediawiki is defined
+    - compiled_templates_folder.stat.exists
+
+- name: Ensure MediaWiki cache/images directories have proper group write permissions
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    group: "{{ group_apache }}"
+    mode: "g+rwX"
+    recurse: true
+  loop:
+    - "{{ m_mediawiki }}/cache"
+    - "{{ m_mediawiki }}/images"
+    - "{{ m_uploads_dir }}"
+  when:
+    - m_mediawiki is defined
+    - ansible_distribution_file_variety == 'RedHat'


### PR DESCRIPTION
### Changes

#### Functional changes
* re-enable the Ansible profiler
* extract significant permission checking tasks from the `mediawiki` role into the verify-permissions role src/roles/verify-permissions/tasks/main.yml with example on how to run the verify-permissions playbook


#### Minor changes
* switch from ini-style line comments (;) to modern-style comments (#)
* link to https://wiki.freephile.org/wiki/Meza/profiling from src/roles/apache-php/README_PROFILING.md


### Issues

* Addresses #267

### Post-merge actions

Post-merge, the following actions need to be addressed:

- [ ] Merge the new Vagrant work in issue #268 and further test
- [ ] Create $6 Million Dollar Man release


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Comprehensive permissions verification and automated correction system for MediaWiki directories.
  * New profiling documentation resource added.

* **Improvements**
  * Refined MediaWiki installation workflow with enhanced group-write permission handling and centralized permission management.
  * Updated system configuration for improved SSH connectivity and Galaxy integration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->